### PR TITLE
fix(reports refine report link queries ignore data fileUpdate stockdetalle and catalogados report strings to narrow downlink matching. stockdetalle, remove the fallback that matched

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 llaima-ml.pem
 test.http
 venv
+data.txt

--- a/routes/catalogados.py
+++ b/routes/catalogados.py
@@ -32,7 +32,7 @@ def click_catalogados_report(page):
     # Try the most successful strategy first
     CATALOGADOS_REPORT_QUERY = """
     {
-        catalogados_link(link containing "Maestra - Catalogados" text)
+        catalogados_link(link containing "Maestra - Catalogados BU" text)
     }
     """
     

--- a/routes/stockdetalle.py
+++ b/routes/stockdetalle.py
@@ -31,8 +31,8 @@ def click_stockdetalle_report(page):
     
     # Try the most successful strategy first
     STOCKDETALLE_REPORT_QUERY = """
-    {
-        stockdetalle_link(link containing "Maestra - Stock Detalle" or "Stock Detalle" text)
+   {
+        stockdetalle_link(link containing "Maestra - Stock Detalle" text)
     }
     """
     


### PR DESCRIPTION
"Stock Detalle" alone and keep only links containing
"Maestra - Stock Detalle to avoid ambiguous matches. For catalogados,
change the matched text to "Maestra - Catalogados BU" to target the
correct report variant.

Also add data.txt to .gitignore to prevent accidentally committing
local data files.