### PR TITLE
feat(playwright): add Playwright browser install and deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,59 @@ FROM python:3.11-slim
 # Set working directory
 WORKDIR /app
 
-# Install system dependencies needed for Playwright
+# Install system dependencies needed for Playwright and Chromium
 RUN apt-get update && apt-get install -y \
     wget \
     gnupg \
+    ca-certificates \
+    fonts-liberation \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libc6 \
+    libcairo2 \
+    libcups2 \
+    libdbus-1-3 \
+    libexpat1 \
+    libfontconfig1 \
+    libgbm1 \
+    libgcc1 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libstdc++6 \
+    libx11-6 \
+    libx11-xcb1 \
+    libxcb1 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxi6 \
+    libxrandr2 \
+    libxrender1 \
+    libxss1 \
+    libxtst6 \
+    lsb-release \
+    xdg-utils \
+    libxkbcommon0 \
+    libgbm-dev \
+    libatspi2.0-0 \
+    libdrm2 \
+    libwayland-client0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements and install Python dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+
+# Install Playwright browsers during build
+RUN playwright install chromium \
+    && playwright install-deps chromium
 
 # Copy all application files
 COPY . .
@@ -26,5 +70,5 @@ RUN mkdir -p downloads
 # Expose port
 EXPOSE 8000
 
-# Use your existing start.sh script
+# Use your existing start.sh script (modified version below)
 CMD ["./start.sh"]

--- a/old.Dockerfile
+++ b/old.Dockerfile
@@ -1,0 +1,30 @@
+# Use Python 3.11 official image
+FROM python:3.11-slim
+
+# Set working directory
+WORKDIR /app
+
+# Install system dependencies needed for Playwright
+RUN apt-get update && apt-get install -y \
+    wget \
+    gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements and install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy all application files
+COPY . .
+
+# Make start.sh executable
+RUN chmod +x start.sh
+
+# Create downloads directory
+RUN mkdir -p downloads
+
+# Expose port
+EXPOSE 8000
+
+# Use your existing start.sh script
+CMD ["./start.sh"]

--- a/old.start.sh
+++ b/old.start.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "Installing Playwright browsers..."
+playwright install chromium
+playwright install-deps chromium
+
+echo "Starting application..."
+python scrapper.py --api

--- a/start.sh
+++ b/start.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-echo "Installing Playwright browsers..."
-playwright install chromium
-playwright install-deps chromium
+# Check if Playwright browsers are installed, install if missing
+if [ ! -d "/root/.cache/ms-playwright" ]; then
+    echo "Playwright browsers not found, installing..."
+    playwright install chromium
+    playwright install-deps chromium
+else
+    echo "Playwright browsers already installed"
+fi
 
 echo "Starting application..."
 python scrapper.py --api


### PR DESCRIPTION
Add installation and dependency handling for Playwright Chromium to ensure
the application can run browser-driven scraping in containers.

- Add start scripts that install Playwright browsers and dependencies:
  - new old.start.sh and updated start.sh check/install Chromium and deps
    before launching scrapper.py.
- Expand Dockerfile to include all required system packages for Chromium
  and Playwright, install Python requirements, and run Playwright browser
  installation at build time to avoid runtime installation overhead.
- Ensure start.sh is used as container CMD and provide idempotent check
  to skip redundant browser installation when browsers are already cached.
- Keep existing Dockerfile behavior for copying files, exposing port, and
  executing start.sh.

This prevents runtime failures due to missing OS libraries or browsers
and speeds container startup by performing browser installation during build.