### PR TITLE
chore(docker): switch to Playwright official image and simplify build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,62 +1,12 @@
-# Use Python 3.11 official image
-FROM python:3.11-slim
+# Use official Playwright image that has all dependencies pre-installed
+FROM mcr.microsoft.com/playwright/python:v1.52.0-noble
 
 # Set working directory
 WORKDIR /app
 
-# Install system dependencies needed for Playwright and Chromium
-RUN apt-get update && apt-get install -y \
-    wget \
-    gnupg \
-    ca-certificates \
-    fonts-liberation \
-    libasound2 \
-    libatk-bridge2.0-0 \
-    libatk1.0-0 \
-    libc6 \
-    libcairo2 \
-    libcups2 \
-    libdbus-1-3 \
-    libexpat1 \
-    libfontconfig1 \
-    libgbm1 \
-    libgcc1 \
-    libglib2.0-0 \
-    libgtk-3-0 \
-    libnspr4 \
-    libnss3 \
-    libpango-1.0-0 \
-    libpangocairo-1.0-0 \
-    libstdc++6 \
-    libx11-6 \
-    libx11-xcb1 \
-    libxcb1 \
-    libxcomposite1 \
-    libxcursor1 \
-    libxdamage1 \
-    libxext6 \
-    libxfixes3 \
-    libxi6 \
-    libxrandr2 \
-    libxrender1 \
-    libxss1 \
-    libxtst6 \
-    lsb-release \
-    xdg-utils \
-    libxkbcommon0 \
-    libgbm-dev \
-    libatspi2.0-0 \
-    libdrm2 \
-    libwayland-client0 \
-    && rm -rf /var/lib/apt/lists/*
-
 # Copy requirements and install Python dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-
-# Install Playwright browsers during build
-RUN playwright install chromium \
-    && playwright install-deps chromium
 
 # Copy all application files
 COPY . .
@@ -70,5 +20,5 @@ RUN mkdir -p downloads
 # Expose port
 EXPOSE 8000
 
-# Use your existing start.sh script (modified version below)
-CMD ["./start.sh"]
+# Use simplified start script since browsers are pre-installed
+CMD ["python", "scrapper.py", "--api"]


### PR DESCRIPTION
Use the Microsoft Playwright Python base image (v1.52.0-noble)
instead of python:3.11-slim. This removes a long list of manual
system package installations and the explicit playwright browser
installation steps, because the chosen base image includes Playwright
and the required browser binaries and dependencies.

Also streamline startup: keep Python dependencies install
from requirements.txt, copy the app, and replace the previous start
script invocation with a direct call to scrapper.py --api. This
simplifies the Dockerfile, reduces image build complexity and size,
and speeds up build time by relying on a prepared Playwright image.